### PR TITLE
[DSX-3771] Move codeowners DSX to CFX

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 # Default owners for everything in the repo.
 # Unless a later match takes precedence, these groups will be requested for
 # review when someone opens a pull request.
-/               @datarobot/dsx
+/               @datarobot/cfx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 # Default owners for everything in the repo.
 # Unless a later match takes precedence, these groups will be requested for
 # review when someone opens a pull request.
-/               @datarobot/cfx
+*               @datarobot/cfx


### PR DESCRIPTION
As DXS and NBX are now one team, we moved all corresponding code owners to CFX.